### PR TITLE
uwsgi.ini fix

### DIFF
--- a/web/mailman-web/uwsgi.ini
+++ b/web/mailman-web/uwsgi.ini
@@ -14,7 +14,7 @@ wsgi-file = wsgi.py
 
 # Setup default number of processes and threads per process.
 master = true
-process = 4
+processes = 4
 
 # Drop privielges and don't run as root.
 uid = mailman


### PR DESCRIPTION
Pair fix to https://github.com/maxking/docker-mailman/pull/428 is needed for the web container.

`uwsgi-error.log` before the fix:

```
mapped 145840 bytes (142 KB) for 1 cores
*** Operational MODE: single process ***

```
After the fix:
```
mapped 364600 bytes (356 KB) for 4 cores
*** Operational MODE: preforking ***

```
